### PR TITLE
fix: missed adding new version in build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "com.ganggreentempertatum"
-version = "1.0.0"
+version = "1.0.1"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## AI-Generated Summary

### PR Summary

#### Overview of Changes
Ahoy, matey! This bilge-sucking PR introduces a wee change within the cabin of `build.gradle.kts`, navigating from the old shores of version `1.0.0` to the uncharted waters of `1.0.1`. Aye, the diff be as simple as swapping a flag on the high seas, yet it marks the ship's journey forward with a new version, ready to set sail with improvements or bug fixes aboard.

#### Key Modifications
1. **Project Version Update**: The version `1.0.0` has walked the plank and been replaced by `1.0.1` in the `build.gradle.kts` file. This change be indicating that there be minor fixes or enhancements, less likely to be causing major upheavals in the application.

#### Potential Impact
- This gentle breeze of a change is unlikely to capsize the ship or invite a kraken's wrath; however, it is crucial for maintaining the ledger of versions and ensuring that all crewmates are working with the latest treasures. It suggests preparations for future voyages or improvements that be minor yet essential.

---

This summary was generated with ❤️ by ads @ [rigging](https://rigging.dreadnode.io/)
