### PR TITLE
fix: tooltype mappings for target and logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A Burp Suite extension written in Kotlin that allows you to create and manage "s
   - Right-click selected text to create new stickies
   - Quick access to update existing stickies
   - Source tracking shows which HTTP request the stickies came from
-  - Works in Burp tools (Proxy, Repeater, etc.)
+  - Works in Burp tools for both HTTP Requests and Responses (Proxy, Repeater, Target (Site Map) etc.)
 
 - **Dedicated UI Tab**
   - Table view of all stored stickies

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "com.ganggreentempertatum"
-version = "1.0.1"
+version = "1.0.2"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/com/ganggreentempertatum/stickyburp/StickyBurpContextMenu.kt
+++ b/src/main/kotlin/com/ganggreentempertatum/stickyburp/StickyBurpContextMenu.kt
@@ -7,6 +7,8 @@ import burp.api.montoya.core.ByteArray
 import burp.api.montoya.ui.contextmenu.ContextMenuEvent
 import burp.api.montoya.ui.contextmenu.ContextMenuItemsProvider
 import burp.api.montoya.ui.contextmenu.InvocationType
+import burp.api.montoya.core.ToolType
+import burp.api.montoya.core.ToolSource
 import burp.api.montoya.logging.Logging
 import javax.swing.*
 import burp.api.montoya.http.message.requests.HttpRequest
@@ -77,17 +79,24 @@ class StickyBurpContextMenu(private val tab: StickyBurpTab, private val logging:
             val source = if (messageEditor.isPresent) {
                 val reqRes = messageEditor.get().requestResponse()
                 val tool = when (event.invocationType()) {
+                    InvocationType.SITE_MAP_TREE,
+                    InvocationType.SITE_MAP_TABLE -> "Target"
                     InvocationType.PROXY_HISTORY,
-                    InvocationType.PROXY_INTERCEPT,
+                    InvocationType.PROXY_INTERCEPT -> "Proxy"
                     InvocationType.MESSAGE_VIEWER_REQUEST,
-                    InvocationType.MESSAGE_VIEWER_RESPONSE -> "Proxy"
+                    InvocationType.MESSAGE_VIEWER_RESPONSE -> {
+                        // Get tool type from the event using isFromTool
+                        when {
+                            event.isFromTool(ToolType.TARGET) -> "Target"
+                            event.isFromTool(ToolType.LOGGER) -> "Logger"
+                            else -> "Proxy"  // Default to Proxy for backwards compatibility
+                        }
+                    }
                     InvocationType.INTRUDER_PAYLOAD_POSITIONS,
                     InvocationType.INTRUDER_ATTACK_RESULTS -> "Intruder"
                     InvocationType.SCANNER_RESULTS -> "Scanner"
                     InvocationType.MESSAGE_EDITOR_REQUEST,
                     InvocationType.MESSAGE_EDITOR_RESPONSE -> "Repeater"
-                    InvocationType.SITE_MAP_TREE,
-                    InvocationType.SITE_MAP_TABLE -> "Site Map"
                     InvocationType.SEARCH_RESULTS -> "Search"
                     else -> "Other"
                 }
@@ -174,17 +183,24 @@ class StickyBurpContextMenu(private val tab: StickyBurpTab, private val logging:
                     ?: return@addActionListener
 
                 val tool = when (event.invocationType()) {
+                    InvocationType.SITE_MAP_TREE,
+                    InvocationType.SITE_MAP_TABLE -> "Target"
                     InvocationType.PROXY_HISTORY,
-                    InvocationType.PROXY_INTERCEPT,
+                    InvocationType.PROXY_INTERCEPT -> "Proxy"
                     InvocationType.MESSAGE_VIEWER_REQUEST,
-                    InvocationType.MESSAGE_VIEWER_RESPONSE -> "Proxy"
+                    InvocationType.MESSAGE_VIEWER_RESPONSE -> {
+                        // Get tool type from the event using isFromTool
+                        when {
+                            event.isFromTool(ToolType.TARGET) -> "Target"
+                            event.isFromTool(ToolType.LOGGER) -> "Logger"
+                            else -> "Proxy"  // Default to Proxy for backwards compatibility
+                        }
+                    }
                     InvocationType.INTRUDER_PAYLOAD_POSITIONS,
                     InvocationType.INTRUDER_ATTACK_RESULTS -> "Intruder"
                     InvocationType.SCANNER_RESULTS -> "Scanner"
                     InvocationType.MESSAGE_EDITOR_REQUEST,
                     InvocationType.MESSAGE_EDITOR_RESPONSE -> "Repeater"
-                    InvocationType.SITE_MAP_TREE,
-                    InvocationType.SITE_MAP_TABLE -> "Site Map"
                     InvocationType.SEARCH_RESULTS -> "Search"
                     else -> "Other"
                 }

--- a/src/main/kotlin/com/ganggreentempertatum/stickyburp/StickyBurpHttpHandler.kt
+++ b/src/main/kotlin/com/ganggreentempertatum/stickyburp/StickyBurpHttpHandler.kt
@@ -2,9 +2,22 @@ package com.ganggreentempertatum.stickyburp
 
 import burp.api.montoya.http.handler.*
 import burp.api.montoya.http.message.requests.HttpRequest
+import burp.api.montoya.core.ToolType
 
 class StickyBurpHttpHandler(private val tab: StickyBurpTab) : HttpHandler {
     override fun handleHttpRequestToBeSent(requestToBeSent: HttpRequestToBeSent): RequestToBeSentAction {
+        if (requestToBeSent.toolSource().toolType() !in listOf(
+                ToolType.PROXY,
+                ToolType.REPEATER,
+                ToolType.INTRUDER,
+                ToolType.TARGET,
+                ToolType.SCANNER,
+                ToolType.LOGGER
+            )
+        ) {
+            return RequestToBeSentAction.continueWith(requestToBeSent)
+        }
+
         var modifiedRequest = requestToBeSent.toString()
 
         for (variable in tab.getVariables()) {
@@ -12,10 +25,12 @@ class StickyBurpHttpHandler(private val tab: StickyBurpTab) : HttpHandler {
         }
 
         return if (modifiedRequest != requestToBeSent.toString()) {
-            RequestToBeSentAction.continueWith(HttpRequest.httpRequest(
-                requestToBeSent.httpService(),
-                modifiedRequest
-            ))
+            RequestToBeSentAction.continueWith(
+                HttpRequest.httpRequest(
+                    requestToBeSent.httpService(),
+                    modifiedRequest
+                )
+            )
         } else {
             RequestToBeSentAction.continueWith(requestToBeSent)
         }


### PR DESCRIPTION
## AI-Generated Summary

### PR Summary

#### Overview of Changes
This pull request heralds a tidy embellishment to the marauding seas of the README documentation, a crafty upgrade to the build version, and an astute enhancement in the StickyBurp extension's handling of HTTP requests and context menu behaviors. By expanding support within Burp tools and refining tool identification logic, this update promises smoother navigation and interaction for privateers charting through the HTTP Request and Response treasuries. Moreover, the addition of tool type checks before executing HTTP request modifications ensures that only relevant voyages are altered, maintaining the integrity of the expedition.

#### Key Modifications
1. **README Enhancements**: Broadened the scope of Burp tools support in the README, now encompassing both HTTP Requests and Responses across a variety of Burp tools, including the Target (Site Map).
2. **Build Version Bump**: Upgraded from version 1.0.1 to 1.0.2 in the `build.gradle.kts`, signaling an improvement and preparation for further adventures.
3. **Improved Tool Identification in Context Menus**: Incorporated detailed logic in `StickyBurpContextMenu.kt` for identifying the source Burp tool (e.g., "Proxy", "Target") based on invocation type and using `isFromTool` for certain conditions, enhancing accuracy for feature interactions.
4. **Selective HTTP Request Handling**: In `StickyBurpHttpHandler.kt`, introduced checks to proceed with request modifications only if the request originates from specified Burp tools (e.g., Proxy, Repeater, etc.), ensuring that modifications are applied appropriately and not universally across all tools.

#### Potential Impact
- Enhanced user experience by offering more detailed and accurate tool support within the extension's features, reducing potential confusion and improving efficiency.
- The updated tool detection mechanism might alter the behavior for some users, depending on their use of the StickyBurp extension, leading to a more streamlined interaction approach.
- Restricting HTTP request modifications to specified tools reduces unnecessary processing and potential errors, focusing the extension’s capabilities on relevant contexts.

---

This summary was generated with ❤️ by ads @ [rigging](https://rigging.dreadnode.io/)
