### PR TITLE
chore: allow hyphens in sticky names

### DIFF
--- a/src/main/kotlin/com/ganggreentempertatum/stickyburp/StickyBurpContextMenu.kt
+++ b/src/main/kotlin/com/ganggreentempertatum/stickyburp/StickyBurpContextMenu.kt
@@ -58,9 +58,9 @@ class StickyBurpContextMenu(private val tab: StickyBurpTab, private val logging:
                 return@addActionListener
             }
 
-            if (!trimmedName.matches(Regex("^[a-zA-Z0-9_]+$"))) {
+            if (!trimmedName.matches(Regex("^[a-zA-Z0-9_-]+$"))) {
                 JOptionPane.showMessageDialog(null,
-                    "Sticky name can only contain letters, numbers, and underscores",
+                    "Sticky name can only contain letters, numbers, underscores, and hyphens",
                     "Invalid Input",
                     JOptionPane.ERROR_MESSAGE)
                 return@addActionListener


### PR DESCRIPTION
fixes #14

## AI-Generated Summary

### PR Summary

#### Overview of Changes
The code changes pertain to `StickyBurpContextMenu.kt` within a Kotlin project focused on enhancing or adding functionality to the context menu aspect of an application named StickyBurp. The modifications adjust the validation logic for the `trimmedName` variable, specifically the conditions that determine whether the name input is considered valid or not. The adjustments extend the character set allowed in the sticky names, to include hyphens along with the previously allowed alphanumeric characters and underscores.

#### Key Modifications
1. **Regex Pattern Adjustment for Name Validation**: The regex pattern used to validate `trimmedName` has been updated to allow hyphens (`-`) in addition to the previous set of characters. This change broadens the scope of valid input names by permitting hyphens, which were not allowed before.
2. **Error Message Update**: Corresponding to the regex change, the error message displayed to the user in case of invalid input has been modified to reflect the new allowance of hyphens in sticky names. The message now explicitly states that letters, numbers, underscores, and hyphens are valid characters, providing clearer guidance to the user.

#### Potential Impact
- **User Experience Improvement**: By allowing hyphens in sticky names, the application accommodates a wider variety of naming conventions, which can enhance user satisfaction and reduce instances where users might encounter validation errors for commonly accepted name formats.
- **Input Validation Consistency**: Extending the character set for valid input necessitates a review of other input validation areas to ensure consistency across the application, particularly if similar naming restrictions are applied in multiple places.

---

This summary was generated with ❤️ by ads @ [rigging](https://rigging.dreadnode.io/)
