### PR TITLE
chore: remove na deps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@ repositories {
 
 dependencies {
     compileOnly("net.portswigger.burp.extensions:montoya-api:2024.12")
-    implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
 }
 


### PR DESCRIPTION
## AI-Generated Summary

- Removed the dependency on `com.squareup.okhttp3:okhttp:4.12.0` from the `build.gradle.kts`.
- This change may reduce the overall size of the application by eliminating unnecessary library overhead.
- Ensure that no other parts of the codebase depend on this library before merging.

---

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
